### PR TITLE
ログイン、ログアウト時のバグの修正

### DIFF
--- a/app/controllers/api/likes_controller.rb
+++ b/app/controllers/api/likes_controller.rb
@@ -1,9 +1,9 @@
 class Api::LikesController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, only: [ :create, :destroy ]
 
   def show
     article = Article.find(params[:article_id])
-    like_status = current_user.has_liked?(article)
+    like_status = current_user&.has_liked?(article)
     render json: { hasLiked: like_status }
   end
 

--- a/app/javascript/packs/article.js
+++ b/app/javascript/packs/article.js
@@ -5,19 +5,24 @@ import {
   listenActiveHeartEvent
 } from 'modules/handle_heart'
 
-document.addEventListener( 'turbo:load', () => {
+const initArticle = () => {
   const dataset = $('#article-index, #article-show').data()
   const articleIds = dataset.articleIds
   articleIds.forEach((articleId) => {
     axios.get(`/api/articles/${articleId}/like`)
-      .then((response) => {
-        const hasLiked = response.data.hasLiked
-        handleHeartDisplay(hasLiked, articleId)
-      })
-      listenInactiveHeartEvent(articleId)
-      listenActiveHeartEvent(articleId)
+    .then((response) => {
+      const hasLiked = response.data.hasLiked
+      handleHeartDisplay(hasLiked, articleId)
+    })
+    listenInactiveHeartEvent(articleId)
+    listenActiveHeartEvent(articleId)
   })
-})
+}
+
+initArticle()
+
+document.addEventListener('turbo:load', initArticle)
+
 
 const handleHeartDisplay = (hasLiked, articleID) => {
   if (hasLiked) {


### PR DESCRIPTION
- ログアウト直後の記事一覧の「いいね」がバグを起こすため修正
　　LikesControllerでauthenticate_user!になっていたので、createとdestroyのみに適用として修正した。
- ログイン直後にturbo:loadが発火せず、いいねが表示されないことに対応