### PR TITLE
記事一覧からタイムラインへのリンクパスを修正

### DIFF
--- a/app/views/articles/index.html.haml
+++ b/app/views/articles/index.html.haml
@@ -3,7 +3,7 @@
     .article_headerLeft.header_left
       = link_to new_article_path, data: { turbo: false } do
         = image_tag 'photo-camera.png'
-      = link_to root_path, data: { turbo: false } do
+      = link_to timeline_path, data: { turbo: false } do
         = image_tag 'home.svg'
     .article_headerRight.header_right 
       - if user_signed_in?


### PR DESCRIPTION
タイムラインへのパスがroot_pathになっていたので修正